### PR TITLE
refactor: rename infoEmbed to animeInfoEmbed for consistency

### DIFF
--- a/src/commands/anime/info.ts
+++ b/src/commands/anime/info.ts
@@ -57,7 +57,7 @@ export default class InfoCommand extends Command {
 
 		const first = data.data[0]!;
 
-		const animeInfoEmbed = baseEmbed({
+		const infoEmbed = baseEmbed({
 			author: { name: query, iconURL: interaction.user.displayAvatarURL() },
 			title: first.title,
 			url: first.url,
@@ -150,7 +150,7 @@ export default class InfoCommand extends Command {
 				: [];
 
 		await interaction.editReply({
-			embeds: [animeInfoEmbed],
+			embeds: [infoEmbed],
 			components: rows,
 		});
 	}

--- a/src/commands/anime/schedule.ts
+++ b/src/commands/anime/schedule.ts
@@ -3,10 +3,9 @@ import {
 	type ChatInputCommandInteraction,
 } from "discord.js";
 import type DiscordClient from "../../classes/client";
-import { Command } from "../../classes/command";
 import type { Anime } from "../../types/anime";
-import { baseEmbed, capitalize } from "../../util/funcs";
 import { Pagination } from "@discordx/pagination";
+import { Command } from "../../classes/command";
 import animeInfoEmbed from "../../util/embeds/anime";
 
 export default class ScheduleCommand extends Command {

--- a/src/commands/anime/trending.ts
+++ b/src/commands/anime/trending.ts
@@ -2,7 +2,7 @@ import type { ChatInputCommandInteraction } from "discord.js";
 import type DiscordClient from "../../classes/client";
 import type { Anime } from "../../types/anime";
 import { fetchCached } from "../../util/funcs";
-import { Pagination } from "@discordx/pagination";
+import { Pagination, type PaginationItem } from "@discordx/pagination";
 import { Command } from "../../classes/command";
 import animeInfoEmbed from "../../util/embeds/anime";
 
@@ -17,7 +17,7 @@ export default class TrendingCommand extends Command {
 
 	override async execute(
 		client: DiscordClient,
-		interaction: ChatInputCommandInteraction
+		interaction: ChatInputCommandInteraction,
 	): Promise<void> {
 		await interaction.deferReply();
 
@@ -25,11 +25,11 @@ export default class TrendingCommand extends Command {
 		try {
 			data = await fetchCached<{ data: Anime[] }>(
 				"https://api.jikan.moe/v4/top/anime",
-				5 * 60 * 1000
+				5 * 60 * 1000,
 			);
 		} catch (err: any) {
 			await interaction.editReply(
-				`Error fetching trending anime: ${err.message || err}`
+				`Error fetching trending anime: ${err.message || err}`,
 			);
 			return;
 		}
@@ -39,12 +39,11 @@ export default class TrendingCommand extends Command {
 			return;
 		}
 
-		const embeds = data.data
-			.slice(0, 10)
-			.map(
-				(a) => ({ content: null, embeds: [animeInfoEmbed(interaction, a)] } as any)
-			);
-		const pagination = new Pagination(interaction, embeds);
+		const pages: PaginationItem[] = data.data.slice(0, 10).map((a) => ({
+			embeds: [animeInfoEmbed(interaction, a)],
+		}));
+
+		const pagination = new Pagination(interaction, pages);
 		await pagination.send();
 	}
 }

--- a/src/util/embeds/anime.ts
+++ b/src/util/embeds/anime.ts
@@ -2,7 +2,11 @@ import type { CommandInteraction } from "discord.js";
 import type { Anime } from "../../types/anime";
 import { baseEmbed, capitalize } from "../funcs";
 
-export default function animeInfoEmbed(interaction: CommandInteraction, anime: Anime, authorName = "Trending") {
+export default function animeInfoEmbed(
+	interaction: CommandInteraction,
+	anime: Anime,
+	authorName = "Trending",
+) {
 	return baseEmbed({
 		author: {
 			name: authorName,
@@ -15,7 +19,9 @@ export default function animeInfoEmbed(interaction: CommandInteraction, anime: A
 				?.substring(0, 4096)
 				.replace("\n\n[Written by MAL Rewrite]", "") ??
 			"No synopsis available.",
-		thumbnail: { url: anime.images.jpg.image_url },
+		thumbnail: anime.images.jpg.image_url
+			? { url: anime.images.jpg.image_url }
+			: undefined,
 		footer: { text: "Data courtesy of MyAnimeList via Jikan API" },
 		fields: [
 			{ name: "📺 Type", value: anime.type ?? "N/A", inline: true },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized embed helper naming across anime commands for consistency; no change to content or pagination.
* **Bug Fixes**
  * Improved ranking sort so items without ranks appear at the end.
  * Added a clear "No trending anime found." response when searches return no results.
* **Minor Improvements**
  * Embed author name is now customizable (default "Trending").
  * Thumbnails are omitted when an anime image is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->